### PR TITLE
[Refactor] 맛집 데이터 수집 기능 리팩토링

### DIFF
--- a/src/main/java/com/allclear/tastytrack/domain/restaurant/dto/RawRestaurantResponse.java
+++ b/src/main/java/com/allclear/tastytrack/domain/restaurant/dto/RawRestaurantResponse.java
@@ -7,39 +7,33 @@ import lombok.Getter;
 public class RawRestaurantResponse { // JSON 응답 데이터를 파싱할 클래스 4
 
     @JsonProperty("MGTNO")
-    private String mgtno;
+    private String mgtno;       // 관리번호
 
     @JsonProperty("DTLSTATEGBN")
-    private String dtlstategbn;
+    private String dtlstategbn; // 상세영업코드
 
     @JsonProperty("BPLCNM")
-    private String bplcnm;
+    private String bplcnm;      // 사업장명
 
     @JsonProperty("UPTAENM")
-    private String uptaenm;
+    private String uptaenm;     // 업태구분명
 
     @JsonProperty("DCBYMD")
-    private String dcbymd;
-
-    @JsonProperty("SITEPOSTNO")
-    private String sitepostno;
+    private String dcbymd;      // 폐업일자
 
     @JsonProperty("SITEWHLADDR")
-    private String sitewhladdr;
+    private String sitewhladdr; // 지번주소
 
     @JsonProperty("RDNWHLADDR")
-    private String rdnwhladdr;
-
-    @JsonProperty("RDNPOSTNO")
-    private String rdnpostno;
+    private String rdnwhladdr;  // 도로명주소
 
     @JsonProperty("LASTMODTS")
-    private String lastmodts;
+    private String lastmodts;   // 최종 수정일자
 
     @JsonProperty("X")
-    private String lon; // 경도
+    private String lon;         // 경도
 
     @JsonProperty("Y")
-    private String lat; // 위도
+    private String lat;         // 위도
 
 }

--- a/src/main/java/com/allclear/tastytrack/domain/restaurant/entity/RawRestaurant.java
+++ b/src/main/java/com/allclear/tastytrack/domain/restaurant/entity/RawRestaurant.java
@@ -16,18 +16,16 @@ public class RawRestaurant {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;            // 맛집 원본 id
+    private int id;             // 맛집 원본 id
     private String mgtno;       // 관리번호
-    private String dtlstategbn; // 상세영업코드
     private String bplcnm;      // 사업장명
     private String uptaenm;     // 업태구분명
-    private String dcbymd;      // 폐업일자
-    private String sitepostno;  // 소재지 우편번호
+    private String dtlstategbn; // 상세영업상태코드
     private String sitewhladdr; // 지번주소
     private String rdnwhladdr;  // 도로명주소
-    private String rdnpostno;   // 도로명 우편번호
-    private String lastmodts;   // 최종 수정일자
     private String lon;         // 경도
     private String lat;         // 위도
+    private String dcbymd;      // 폐업일자
+    private String lastmodts;   // 최종 수정일자
 
 }

--- a/src/main/java/com/allclear/tastytrack/domain/restaurant/repository/RawRestaurantRepository.java
+++ b/src/main/java/com/allclear/tastytrack/domain/restaurant/repository/RawRestaurantRepository.java
@@ -3,6 +3,6 @@ package com.allclear.tastytrack.domain.restaurant.repository;
 import com.allclear.tastytrack.domain.restaurant.entity.RawRestaurant;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface RawRestaurantRepository extends JpaRepository<RawRestaurant, Long> {
+public interface RawRestaurantRepository extends JpaRepository<RawRestaurant, Integer> {
 
 }

--- a/src/main/java/com/allclear/tastytrack/domain/restaurant/service/ApiService.java
+++ b/src/main/java/com/allclear/tastytrack/domain/restaurant/service/ApiService.java
@@ -60,20 +60,7 @@ public class ApiService {
             List<RawRestaurantResponse> rows = localDataResponse.getLocalData().getRawRestaurantResponses();
 
             for (RawRestaurantResponse raw : rows) {
-                RawRestaurant restaurant = RawRestaurant.builder()
-                        .mgtno(raw.getMgtno())
-                        .dtlstategbn(raw.getDtlstategbn())
-                        .bplcnm(raw.getBplcnm())
-                        .uptaenm(raw.getUptaenm())
-                        .dcbymd(raw.getDcbymd())
-                        .sitepostno(raw.getSitepostno())
-                        .sitewhladdr(raw.getSitewhladdr())
-                        .rdnwhladdr(raw.getRdnwhladdr())
-                        .rdnpostno(raw.getRdnpostno())
-                        .lastmodts(raw.getLastmodts())
-                        .lon(raw.getLon())
-                        .lat(raw.getLat())
-                        .build();
+                RawRestaurant restaurant = getRawRestaurantBuild(raw);
 
                 rawRestaurantRepository.save(restaurant);
             }
@@ -81,6 +68,31 @@ public class ApiService {
             e.printStackTrace();
         }
 
+    }
+
+    /**
+     * 공공데이터의 맛집 응답 데이터를 원본 맛집 DB Entity에 저장하는 Builder 메서드
+     * 작성자 : 유리빛나
+     * 
+     * @param raw 공공데이터의 맛집 응답 데이터
+     * @return 맛집 응답 데이터가 저장된 원본 맛집 DB Entity
+     */
+    private static RawRestaurant getRawRestaurantBuild(RawRestaurantResponse raw) {
+
+        return RawRestaurant.builder()
+                .mgtno(raw.getMgtno())
+                .dtlstategbn(raw.getDtlstategbn())
+                .bplcnm(raw.getBplcnm())
+                .uptaenm(raw.getUptaenm())
+                .dcbymd(raw.getDcbymd())
+                .sitepostno(raw.getSitepostno())
+                .sitewhladdr(raw.getSitewhladdr())
+                .rdnwhladdr(raw.getRdnwhladdr())
+                .rdnpostno(raw.getRdnpostno())
+                .lastmodts(raw.getLastmodts())
+                .lon(raw.getLon())
+                .lat(raw.getLat())
+                .build();
     }
 
 }

--- a/src/main/java/com/allclear/tastytrack/domain/restaurant/service/ApiService.java
+++ b/src/main/java/com/allclear/tastytrack/domain/restaurant/service/ApiService.java
@@ -31,7 +31,7 @@ public class ApiService {
      * 작성자 : 유리빛나
      *
      * @param startIndex 요청 시작 위치
-     * @param endIndex 요청 종료 위치
+     * @param endIndex   요청 종료 위치
      */
     public void getRawRestaurants(String startIndex, String endIndex) {
 
@@ -60,7 +60,7 @@ public class ApiService {
             List<RawRestaurantResponse> rows = localDataResponse.getLocalData().getRawRestaurantResponses();
 
             for (RawRestaurantResponse raw : rows) {
-                RawRestaurant restaurant = getRawRestaurantBuild(raw);
+                RawRestaurant restaurant = getRawRestaurantBuilder(raw);
 
                 rawRestaurantRepository.save(restaurant);
             }
@@ -71,27 +71,25 @@ public class ApiService {
     }
 
     /**
-     * 공공데이터의 맛집 응답 데이터를 원본 맛집 DB Entity에 저장하는 Builder 메서드
+     * 공공데이터의 맛집 응답 데이터를 원본 맛집 DB Entity에 저장하기 위해 Builder 패턴으로 객체를 생성하는 메서드
      * 작성자 : 유리빛나
-     * 
+     *
      * @param raw 공공데이터의 맛집 응답 데이터
-     * @return 맛집 응답 데이터가 저장된 원본 맛집 DB Entity
+     * @return 맛집 응답 데이터가 저장된 원본 맛집 Entity 객체
      */
-    private static RawRestaurant getRawRestaurantBuild(RawRestaurantResponse raw) {
+    private static RawRestaurant getRawRestaurantBuilder(RawRestaurantResponse raw) {
 
         return RawRestaurant.builder()
                 .mgtno(raw.getMgtno())
-                .dtlstategbn(raw.getDtlstategbn())
                 .bplcnm(raw.getBplcnm())
                 .uptaenm(raw.getUptaenm())
-                .dcbymd(raw.getDcbymd())
-                .sitepostno(raw.getSitepostno())
+                .dtlstategbn(raw.getDtlstategbn())
                 .sitewhladdr(raw.getSitewhladdr())
                 .rdnwhladdr(raw.getRdnwhladdr())
-                .rdnpostno(raw.getRdnpostno())
-                .lastmodts(raw.getLastmodts())
                 .lon(raw.getLon())
                 .lat(raw.getLat())
+                .lastmodts(raw.getLastmodts())
+                .dcbymd(raw.getDcbymd())
                 .build();
     }
 

--- a/src/main/java/com/allclear/tastytrack/global/config/WebSecurityConfig.java
+++ b/src/main/java/com/allclear/tastytrack/global/config/WebSecurityConfig.java
@@ -56,7 +56,7 @@ public class WebSecurityConfig {
                 .csrf((AbstractHttpConfigurer::disable))
                 .authorizeHttpRequests(authorize -> authorize
                         .requestMatchers(HttpMethod.POST, ("/api/users/**")).permitAll()
-                        .requestMatchers("/api/restaurants", "/h2-console/**", "/swagger-ui/**").permitAll()
+                        .requestMatchers("/api/restaurants/**", "/h2-console/**", "/swagger-ui/**").permitAll()
 
                         .anyRequest().authenticated()
                 )


### PR DESCRIPTION
## 📌 작업 내용 (필수)
- 공공데이터의 맛집 응답 데이터를 원본 맛집 DB Entity에 저장하기 위해 Builder 패턴으로 객체를 생성하는 코드를
  별도의 메서드로 분리하여 가독성을 높이고, 코드를 간결하게 수정하였습니다.
- WebSecurityConfig > 맛집 데이터 수집 API 관련 요청 허용 추가하였습니다.

<br/>

## 🌱 반영 브랜치
- refactor/#TT-33-data-collection-refactor
- close #32 