### PR TITLE
[Feat] 주소 위도 경도 데이터 수집

### DIFF
--- a/src/main/java/com/allclear/tastytrack/domain/restaurant/controller/ApiController.java
+++ b/src/main/java/com/allclear/tastytrack/domain/restaurant/controller/ApiController.java
@@ -20,7 +20,7 @@ public class ApiController {
     // TODO: 1회 최대 요청 건수는 1000건입니다. 추후 예외 처리 필요합니다.
     @GetMapping("/{startIndex}/{endIndex}")
     public void getRawRestaurants(@PathVariable("startIndex") String startIndex,
-                                    @PathVariable("endIndex") String endIndex) {
+                                    @PathVariable("endIndex") String endIndex) throws Exception {
 
         apiService.getRawRestaurants(startIndex, endIndex);
     }

--- a/src/main/java/com/allclear/tastytrack/domain/restaurant/coordinate/dto/Coordinate.java
+++ b/src/main/java/com/allclear/tastytrack/domain/restaurant/coordinate/dto/Coordinate.java
@@ -1,0 +1,16 @@
+package com.allclear.tastytrack.domain.restaurant.coordinate.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+@Getter
+public class Coordinate {
+    private String lon;
+    private String lat;
+
+    public Coordinate(String lon, String lat) {
+        this.lon = lon;
+        this.lat = lat;
+
+    }
+
+}

--- a/src/main/java/com/allclear/tastytrack/domain/restaurant/coordinate/dto/CoordinateAddress.java
+++ b/src/main/java/com/allclear/tastytrack/domain/restaurant/coordinate/dto/CoordinateAddress.java
@@ -1,0 +1,20 @@
+package com.allclear.tastytrack.domain.restaurant.coordinate.dto;
+
+import lombok.Getter;
+
+@Getter
+public class CoordinateAddress {
+
+    private String address_name;
+    private String b_code;
+    private String h_code;
+    private String main_address_no;
+    private String mountain_yn;
+    private String region_1depth_name;
+    private String region_2depth_name;
+    private String region_3depth_h_name;
+    private String region_3depth_name;
+    private String sub_address_no;
+    private String x;
+    private String y;
+}

--- a/src/main/java/com/allclear/tastytrack/domain/restaurant/coordinate/dto/CoordinateMeta.java
+++ b/src/main/java/com/allclear/tastytrack/domain/restaurant/coordinate/dto/CoordinateMeta.java
@@ -1,0 +1,8 @@
+package com.allclear.tastytrack.domain.restaurant.coordinate.dto;
+
+public class CoordinateMeta {
+    private boolean is_end;
+    private int pageable_count;
+    private int total_count;
+
+}

--- a/src/main/java/com/allclear/tastytrack/domain/restaurant/coordinate/dto/CoordinateResponse.java
+++ b/src/main/java/com/allclear/tastytrack/domain/restaurant/coordinate/dto/CoordinateResponse.java
@@ -1,0 +1,12 @@
+package com.allclear.tastytrack.domain.restaurant.coordinate.dto;
+
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class CoordinateResponse {
+    private List<Documents> documents;
+    private CoordinateMeta meta;
+
+}

--- a/src/main/java/com/allclear/tastytrack/domain/restaurant/coordinate/dto/CoordinateRoadAddress.java
+++ b/src/main/java/com/allclear/tastytrack/domain/restaurant/coordinate/dto/CoordinateRoadAddress.java
@@ -1,0 +1,16 @@
+package com.allclear.tastytrack.domain.restaurant.coordinate.dto;
+
+public class CoordinateRoadAddress {
+    private String address_name;
+    private String building_name;
+    private String main_building_no;
+    private String region_1depth_name;
+    private String region_2depth_name;
+    private String region_3depth_name;
+    private String road_name;
+    private String sub_building_no;
+    private String underground_yn;
+    private String x;
+    private String y;
+    private String zone_no;
+}

--- a/src/main/java/com/allclear/tastytrack/domain/restaurant/coordinate/dto/Documents.java
+++ b/src/main/java/com/allclear/tastytrack/domain/restaurant/coordinate/dto/Documents.java
@@ -1,0 +1,14 @@
+package com.allclear.tastytrack.domain.restaurant.coordinate.dto;
+
+import lombok.Getter;
+
+@Getter
+public class Documents {
+    private CoordinateAddress address;
+    private String address_name;
+    private String address_type;
+    private CoordinateRoadAddress road_address;
+    private String x;
+    private String y;
+
+}

--- a/src/main/java/com/allclear/tastytrack/domain/restaurant/coordinate/service/CoordinateService.java
+++ b/src/main/java/com/allclear/tastytrack/domain/restaurant/coordinate/service/CoordinateService.java
@@ -1,0 +1,8 @@
+package com.allclear.tastytrack.domain.restaurant.coordinate.service;
+
+import com.allclear.tastytrack.domain.restaurant.coordinate.dto.Coordinate;
+
+public interface CoordinateService {
+    Coordinate getCoordinate(String address) throws Exception;
+
+}

--- a/src/main/java/com/allclear/tastytrack/domain/restaurant/coordinate/service/CoordinateServiceImpl.java
+++ b/src/main/java/com/allclear/tastytrack/domain/restaurant/coordinate/service/CoordinateServiceImpl.java
@@ -1,0 +1,81 @@
+package com.allclear.tastytrack.domain.restaurant.coordinate.service;
+
+
+import com.allclear.tastytrack.domain.restaurant.coordinate.dto.Coordinate;
+import com.allclear.tastytrack.domain.restaurant.coordinate.dto.CoordinateResponse;
+import com.allclear.tastytrack.domain.restaurant.coordinate.dto.Documents;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+
+import java.net.URL;
+import java.net.URLEncoder;
+import java.util.List;
+
+import static org.springframework.http.HttpMethod.GET;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CoordinateServiceImpl implements CoordinateService {
+
+    @Value("${COORDINATE_API_KEY}")
+    private String coordinateApiKey; // API 인증키
+
+    public final ObjectMapper objectMapper;
+
+    public Coordinate getCoordinate(String address) throws Exception {
+
+        // 공공데이터 요청을 위한 URL 구성
+        String apiUrl = "https://dapi.kakao.com/v2/local/search/address.json?query="; // URL
+        String urlString = apiUrl + URLEncoder.encode(address, "UTF-8");
+        URL url = new URL(urlString);
+
+        // RestTemplate을 사용하여 GET 요청 전송
+        RestTemplate template = new RestTemplate();
+        String jsonResponse;
+
+        // hedaer 인증키 담아서 전송
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Authorization", "KakaoAK " + coordinateApiKey);
+
+        HttpEntity<String> httpEntity = new HttpEntity<>(headers);
+
+        String lon = null, lat = null;
+
+        try {
+            jsonResponse = template.exchange(url.toURI(), GET, httpEntity, String.class).getBody();
+        } catch (RestClientException e) {
+            // HTTP 요청 관련 예외 처리
+            log.error("API 요청 실패: {}", url, e);
+            return null; // 요청 실패 시 메서드 종료
+        }
+
+        // JSON 응답 데이터를 파싱하여 엔티티로 변환
+        try {
+            CoordinateResponse response = objectMapper.readValue(jsonResponse, CoordinateResponse.class);
+
+            List<Documents> documents = response.getDocuments();
+
+            for (Documents documents1 : documents) {
+                lon = documents1.getX();
+                lat = documents1.getY();
+            }
+
+        } catch (JsonProcessingException e) {
+            // JSON 파싱 관련 예외 처리
+            log.error("JSON 파싱 실패: {}", jsonResponse, e);
+        }
+
+        // 해당 주소의 위도, 경도 값 반환
+        return new Coordinate(lon, lat);
+    }
+
+}

--- a/src/main/java/com/allclear/tastytrack/domain/restaurant/entity/RawRestaurant.java
+++ b/src/main/java/com/allclear/tastytrack/domain/restaurant/entity/RawRestaurant.java
@@ -1,13 +1,11 @@
 package com.allclear.tastytrack.domain.restaurant.entity;
 
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Entity
 @Getter
+@Setter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor

--- a/src/main/java/com/allclear/tastytrack/domain/restaurant/service/ApiService.java
+++ b/src/main/java/com/allclear/tastytrack/domain/restaurant/service/ApiService.java
@@ -5,6 +5,6 @@ import org.springframework.stereotype.Service;
 @Service
 public interface ApiService {
 
-    void getRawRestaurants(String startIndex, String endIndex);
+    void getRawRestaurants(String startIndex, String endIndex) throws Exception;
 
 }

--- a/src/main/java/com/allclear/tastytrack/domain/restaurant/service/ApiServiceImpl.java
+++ b/src/main/java/com/allclear/tastytrack/domain/restaurant/service/ApiServiceImpl.java
@@ -1,5 +1,7 @@
 package com.allclear.tastytrack.domain.restaurant.service;
 
+import com.allclear.tastytrack.domain.restaurant.coordinate.dto.Coordinate;
+import com.allclear.tastytrack.domain.restaurant.coordinate.service.CoordinateService;
 import com.allclear.tastytrack.domain.restaurant.dto.LocalDataResponse;
 import com.allclear.tastytrack.domain.restaurant.dto.RawRestaurantResponse;
 import com.allclear.tastytrack.domain.restaurant.entity.RawRestaurant;
@@ -31,6 +33,8 @@ public class ApiServiceImpl implements ApiService {
     private final RestaurantRepository restaurantRepository;
     private final ObjectMapper objectMapper;
 
+    private final CoordinateService coordinateService;
+
     @Value("${api.key}")
     private String apiKey; // API 인증키
 
@@ -42,7 +46,7 @@ public class ApiServiceImpl implements ApiService {
      * @param endIndex   요청 종료 위치
      */
     @Transactional
-    public void getRawRestaurants(String startIndex, String endIndex) {
+    public void getRawRestaurants(String startIndex, String endIndex) throws Exception {
 
         // 공공데이터 요청을 위한 URL 구성
         String apiUrl = "http://openapi.seoul.go.kr:8088"; // URL
@@ -61,7 +65,6 @@ public class ApiServiceImpl implements ApiService {
 
         try {
             jsonResponse = template.getForObject(uri, String.class);
-            log.info("JSON 응답:" + jsonResponse);
         } catch (RestClientException e) {
             // HTTP 요청 관련 예외 처리
             log.error("API 요청 실패: {}", uri, e);
@@ -94,7 +97,7 @@ public class ApiServiceImpl implements ApiService {
      * 2. 원본 맛집 데이터 전처리 후 가공된 데이터를 가공 맛집 테이블에 저장합니다.
      * 작성자 : 유리빛나
      */
-    public void preprocessing() {
+    public void preprocessing() throws Exception {
 
         // 원본 맛집 테이블 모든 데이터 조회
         List<RawRestaurant> rawRestaurantList = rawRestaurantRepository.findAll();
@@ -104,7 +107,12 @@ public class ApiServiceImpl implements ApiService {
             if (!rawRestaurant.getDcbymd().isEmpty()) {
                 continue;
             }
-
+            // 위도, 경도 값이 누락된 데이터 주입
+            if (rawRestaurant.getLon().isEmpty()) {
+                Coordinate coordinate = coordinateService.getCoordinate(rawRestaurant.getRdnwhladdr());
+                rawRestaurant.setLon(coordinate.getLon());
+                rawRestaurant.setLat(coordinate.getLat());
+            }
             // 원본 데이터를 가공하여 새로운 엔티티 생성
             Restaurant restaurant = getRestaurantBuilder(rawRestaurant);
 


### PR DESCRIPTION
## 📌 작업 내용 (필수)
-  주소 openAPI 를 활용하여 맛집 데이터 중 위도 경도가 누락된 가게의 데이터를 추가하였습니다.
- 현재는 저장되어 있는 맛집 데이터의 반복문을 작성하기가 꺼려져 전처리가 이루어지는 메서드 안에 구현하였는데 방법 고안 후 추후 분리하겠습니다.
<img width="517" alt="image" src="https://github.com/user-attachments/assets/c2d5558b-e6a1-46bc-acbe-b48d4082b52d">
<br/>

👇
<img width="515" alt="image" src="https://github.com/user-attachments/assets/60f226e8-b71b-45cf-a65c-277397030e04">

<br/>

## 🌱 반영 브랜치
- feat/#TT-47-geo-data-collection -> dev
- close #41 

<br/>

## 🔥 트러블 슈팅 (선택)
- 기존 사용하려고 했던 주소검색 API는 행정구역의 코드와 도로명 코드 등 저희가 갖고 있지 않은 데이터를 요청해야 했어서 주소데이터만으로 위도 경도 조회가 가능한 카카오 주소 openAPI 를 사용했습니다.

- 카카오 주소 openAPI 요청 시에는 URL이 아닌 헤더에 인증키를 담아주어야 했습니다.
```       
 HttpHeaders headers = new HttpHeaders();
 headers.set("Authorization", "KakaoAK " + coordinateApiKey);

HttpEntity<String> httpEntity = new HttpEntity<>(headers);
```   

Spring에서 지원하는 HttpHeaders를 활용해 키값을 전달하였습니다.
