### PR TITLE
[Test] 사용자 관련 API 테스트

### DIFF
--- a/src/main/java/com/allclear/tastytrack/domain/auth/UserAuthImpl.java
+++ b/src/main/java/com/allclear/tastytrack/domain/auth/UserAuthImpl.java
@@ -29,7 +29,7 @@ public class UserAuthImpl implements UserAuth{
         String accessToken = getToken(user);
         String refreshToken = saveRefreshTokenToRedis(user);
         headers.set(HttpHeaders.AUTHORIZATION,"Bearer " + accessToken);
-        headers.set("RefreshToken",refreshToken);
+        headers.set("RefreshToken", refreshToken);
         return headers;
     }
 

--- a/src/main/java/com/allclear/tastytrack/domain/user/controller/UserController.java
+++ b/src/main/java/com/allclear/tastytrack/domain/user/controller/UserController.java
@@ -1,6 +1,7 @@
 package com.allclear.tastytrack.domain.user.controller;
 
 import com.allclear.tastytrack.domain.auth.UserDetailsImpl;
+import com.allclear.tastytrack.domain.user.dto.LoginRequest;
 import com.allclear.tastytrack.domain.user.dto.UserCreateRequest;
 import com.allclear.tastytrack.domain.user.dto.UserInfo;
 import com.allclear.tastytrack.domain.user.dto.UserUpdateRequest;
@@ -33,9 +34,9 @@ public class UserController {
     }
 
     @RequestMapping(value = "/login", method = RequestMethod.POST)
-    public ResponseEntity<String> signin(@Validated @RequestBody UserCreateRequest userCreateRequest) {
+    public ResponseEntity<String> signin(@Validated @RequestBody LoginRequest loginRequest) {
 
-        HttpHeaders httpHeaders = userService.signin(userCreateRequest);
+        HttpHeaders httpHeaders = userService.signin(loginRequest);
 
         return ResponseEntity.status(HttpStatus.OK).headers(httpHeaders).body(null);
     }

--- a/src/main/java/com/allclear/tastytrack/domain/user/dto/LoginRequest.java
+++ b/src/main/java/com/allclear/tastytrack/domain/user/dto/LoginRequest.java
@@ -1,9 +1,11 @@
 package com.allclear.tastytrack.domain.user.dto;
 
 import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
 import lombok.Getter;
 
 @Getter
+@Builder
 public class LoginRequest {
     @NotNull(message = "사용자 이름은 필수 입력 값입니다.")
     private String username;

--- a/src/main/java/com/allclear/tastytrack/domain/user/dto/LoginRequest.java
+++ b/src/main/java/com/allclear/tastytrack/domain/user/dto/LoginRequest.java
@@ -1,0 +1,12 @@
+package com.allclear.tastytrack.domain.user.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+@Getter
+public class LoginRequest {
+    @NotNull(message = "사용자 이름은 필수 입력 값입니다.")
+    private String username;
+    @NotNull(message = "비밀번호는 필수 입력 값입니다.")
+    private String password;
+}

--- a/src/main/java/com/allclear/tastytrack/domain/user/dto/UserUpdateRequest.java
+++ b/src/main/java/com/allclear/tastytrack/domain/user/dto/UserUpdateRequest.java
@@ -3,9 +3,11 @@ package com.allclear.tastytrack.domain.user.dto;
 import com.allclear.tastytrack.domain.user.entity.User;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 
 @Getter
+@Builder
 @AllArgsConstructor
 public class UserUpdateRequest {
 

--- a/src/main/java/com/allclear/tastytrack/domain/user/entity/User.java
+++ b/src/main/java/com/allclear/tastytrack/domain/user/entity/User.java
@@ -16,7 +16,7 @@ public class User {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+    private Integer id;
 
     @Column(nullable = false)
     private String username;

--- a/src/main/java/com/allclear/tastytrack/domain/user/entity/User.java
+++ b/src/main/java/com/allclear/tastytrack/domain/user/entity/User.java
@@ -16,7 +16,7 @@ public class User {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Integer id;
+    private int id;
 
     @Column(nullable = false)
     private String username;

--- a/src/main/java/com/allclear/tastytrack/domain/user/service/UserService.java
+++ b/src/main/java/com/allclear/tastytrack/domain/user/service/UserService.java
@@ -1,5 +1,6 @@
 package com.allclear.tastytrack.domain.user.service;
 
+import com.allclear.tastytrack.domain.user.dto.LoginRequest;
 import com.allclear.tastytrack.domain.user.dto.UserCreateRequest;
 import com.allclear.tastytrack.domain.user.dto.UserInfo;
 import com.allclear.tastytrack.domain.user.dto.UserUpdateRequest;
@@ -9,7 +10,7 @@ public interface UserService {
 
     void signup(UserCreateRequest userCreateRequest);
 
-    HttpHeaders signin(UserCreateRequest userCreateRequest);
+    HttpHeaders signin(LoginRequest loginRequest);
 
     UserInfo updateUserInfo(String username, UserUpdateRequest userUpdateRequest);
 

--- a/src/main/java/com/allclear/tastytrack/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/allclear/tastytrack/domain/user/service/UserServiceImpl.java
@@ -1,6 +1,7 @@
 package com.allclear.tastytrack.domain.user.service;
 
 import com.allclear.tastytrack.domain.auth.UserAuth;
+import com.allclear.tastytrack.domain.user.dto.LoginRequest;
 import com.allclear.tastytrack.domain.user.dto.UserCreateRequest;
 import com.allclear.tastytrack.domain.user.dto.UserInfo;
 import com.allclear.tastytrack.domain.user.dto.UserUpdateRequest;
@@ -48,14 +49,14 @@ public class UserServiceImpl implements UserService {
      * 로그인
      * 작성자 : 오예령
      *
-     * @param  userCreateRequest 계정명, 비밀번호
+     * @param  loginRequest 계정명, 비밀번호
      * @return 헤더에 토큰을 담아 반환
      */
     @Override
     @Transactional
-    public HttpHeaders signin(UserCreateRequest userCreateRequest) {
+    public HttpHeaders signin(LoginRequest loginRequest) {
 
-        User user = userCheck(userCreateRequest.getUsername());
+        User user = userCheck(loginRequest.getUsername());
         return userAuth.generateHeaderTokens(user);
     }
 

--- a/src/test/java/com/allclear/tastytrack/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/allclear/tastytrack/domain/user/controller/UserControllerTest.java
@@ -1,0 +1,78 @@
+package com.allclear.tastytrack.domain.user.controller;
+
+import com.allclear.tastytrack.domain.auth.UserDetailsImpl;
+import com.allclear.tastytrack.domain.user.dto.UserInfo;
+import com.allclear.tastytrack.domain.user.service.UserService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(UserController.class)
+public class UserControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private UserService userService;
+
+    @Mock
+    private UserDetailsImpl mockUserDetails;
+
+    private UserInfo mockUserInfo;
+
+    @BeforeEach
+    void setUp() {
+
+        MockitoAnnotations.openMocks(this);
+
+        mockUserInfo = UserInfo.builder()
+                .username("testUser")
+                .lon(127.0)
+                .lat(37.5)
+                .lunchRecommendYn(true)
+                .build();
+
+        // "testUser" 계정명을 가진 UserDetails Mock 객체 설정
+        given(mockUserDetails.getUsername()).willReturn("testUser");
+
+        // SecurityContext에 UserDetails Mock 객체 설정 => SecurityContext에 Authentication 객체를 설정하여, 이후 테스트에서 인증된 사용자의 정보를 사용할 수 있도록 함
+        SecurityContext securityContext = SecurityContextHolder.getContext();
+        securityContext.setAuthentication(new UsernamePasswordAuthenticationToken(mockUserDetails, null, mockUserDetails.getAuthorities()));
+
+    }
+
+    @Test
+    @WithMockUser(username = "testUser")
+    void getUserInfo() throws Exception {
+        // given
+        given(userService.getUserInfo(anyString())).willReturn(mockUserInfo);
+
+        // when
+        ResultActions resultActions = mockMvc.perform(MockMvcRequestBuilders.get("/api/users"));
+
+        // then
+        resultActions.andExpect(status().isOk())
+                .andExpect(jsonPath("$.username").value("testUser"))
+                .andExpect(jsonPath("$.lon").value(127.0))
+                .andExpect(jsonPath("$.lat").value(37.5))
+                .andExpect(jsonPath("$.lunchRecommendYn").value(true));
+    }
+
+}

--- a/src/test/java/com/allclear/tastytrack/domain/user/service/TokenVerifyTest.java
+++ b/src/test/java/com/allclear/tastytrack/domain/user/service/TokenVerifyTest.java
@@ -1,17 +1,19 @@
 package com.allclear.tastytrack.domain.user.service;
 
-import com.allclear.tastytrack.domain.auth.UserAuth;
+import com.allclear.tastytrack.domain.auth.token.RefreshToken;
+import com.allclear.tastytrack.domain.auth.token.RefreshTokenRepository;
 import com.allclear.tastytrack.domain.user.dto.LoginRequest;
 import com.allclear.tastytrack.domain.user.entity.User;
 import com.allclear.tastytrack.domain.user.repository.UserRepository;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpHeaders;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @SpringBootTest
 public class TokenVerifyTest {
@@ -21,6 +23,9 @@ public class TokenVerifyTest {
 
     @Autowired
     private UserRepository userRepository;
+
+    @Autowired
+    private RefreshTokenRepository refreshTokenRepository;
 
     @Test
     @DisplayName("로그인 시 토큰을 발급합니다.")
@@ -51,6 +56,25 @@ public class TokenVerifyTest {
 
         String refreshToken = headers.getFirst("RefreshToken");
         assertNotNull(refreshToken);
+    }
+
+
+    @Test
+    @DisplayName("RefreshToken을 Redis에 저장합니다.")
+    void saveRefreshTokenToRedis() {
+        // given
+        String key = "testKey";
+        String username = "testUser";
+        RefreshToken initRefreshToken = new RefreshToken(key, username);
+
+        // when
+        refreshTokenRepository.save(initRefreshToken);
+
+        // then
+        RefreshToken refreshToken = refreshTokenRepository.findByUsername(key).orElseThrow(
+                () -> new NullPointerException("해당 값이 존재하지 않습니다.")
+        );
+        assertThat(refreshToken.getUsername()).isEqualTo("testUser");
     }
 
 }

--- a/src/test/java/com/allclear/tastytrack/domain/user/service/TokenVerifyTest.java
+++ b/src/test/java/com/allclear/tastytrack/domain/user/service/TokenVerifyTest.java
@@ -1,0 +1,56 @@
+package com.allclear.tastytrack.domain.user.service;
+
+import com.allclear.tastytrack.domain.auth.UserAuth;
+import com.allclear.tastytrack.domain.user.dto.LoginRequest;
+import com.allclear.tastytrack.domain.user.entity.User;
+import com.allclear.tastytrack.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+public class TokenVerifyTest {
+
+    @Autowired
+    private UserServiceImpl userService;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Test
+    @DisplayName("로그인 시 토큰을 발급합니다.")
+    void generateAccessToken() {
+
+        // given
+        User user = User.builder()
+                .username("testUser")
+                .password("testPassword")
+                .lon(123.45)
+                .lat(26.583)
+                .build();
+
+        userRepository.save(user);
+
+        LoginRequest loginRequest = LoginRequest.builder()
+                .username("testUser")
+                .password("testPassword")
+                .build();
+
+        // when
+        HttpHeaders headers = userService.signin(loginRequest);
+
+        // then
+        String accessToken = headers.getFirst(HttpHeaders.AUTHORIZATION);
+        assertNotNull(accessToken);
+        assertTrue(accessToken.startsWith("Bearer "));
+
+        String refreshToken = headers.getFirst("RefreshToken");
+        assertNotNull(refreshToken);
+    }
+
+}

--- a/src/test/java/com/allclear/tastytrack/domain/user/service/UserServiceImplTest.java
+++ b/src/test/java/com/allclear/tastytrack/domain/user/service/UserServiceImplTest.java
@@ -1,0 +1,104 @@
+package com.allclear.tastytrack.domain.user.service;
+
+import com.allclear.tastytrack.domain.user.dto.LoginRequest;
+import com.allclear.tastytrack.domain.user.dto.UserCreateRequest;
+import com.allclear.tastytrack.domain.user.entity.User;
+import com.allclear.tastytrack.domain.user.repository.UserRepository;
+import com.allclear.tastytrack.global.exception.CustomException;
+import com.allclear.tastytrack.global.exception.ErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+class UserServiceImplTest {
+
+    @Autowired
+    private UserServiceImpl userService;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+
+    @BeforeEach
+    void setUP() {
+
+        User user = User.builder()
+                .id(1)
+                .username("testUser")
+                .password("testPassword")
+                .lon(127.345)
+                .lat(35.492)
+                .build();
+
+        userRepository.save(user);
+    }
+
+
+    @Test
+    @DisplayName("이미 가입된 계정명으로 회원가입을 합니다.")
+    void signupDuplicateUsername() {
+
+        //given
+        UserCreateRequest createRequest = UserCreateRequest.builder()
+                .username("testUser")
+                .password("password12")
+                .lon(123.45)
+                .lat(26.583)
+                .build();
+
+        // when & given
+        CustomException exception = assertThrows(CustomException.class, () -> userService.signup(createRequest));
+        assertEquals(ErrorCode.USERNAME_DUPLICATION, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("성공적으로 로그인합니다.")
+    void signin() {
+        // given
+        LoginRequest loginRequest = LoginRequest.builder()
+                .username("testUser")
+                .password(passwordEncoder.encode("testPassword"))
+                .build();
+        // when
+        HttpHeaders headers = userService.signin(loginRequest);
+
+        // then
+        assertNotNull(headers);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 계정명으로 로그인합니다.")
+    void signinWithNonExistUser() {
+        // given
+        LoginRequest loginRequest = LoginRequest.builder()
+                .username("AnotherTestUser")
+                .password(passwordEncoder.encode("testPassword"))
+                .build();
+
+        Exception exception = assertThrows(CustomException.class, () -> userService.signin(loginRequest));
+        assertEquals(ErrorCode.USER_NOT_EXIST, exception.getMessage());
+    }
+
+    @Test
+    void updateUserInfo() {
+
+    }
+
+    @Test
+    void getUserInfo() {
+
+    }
+
+
+
+}

--- a/src/test/java/com/allclear/tastytrack/domain/user/service/UserServiceImplTest.java
+++ b/src/test/java/com/allclear/tastytrack/domain/user/service/UserServiceImplTest.java
@@ -2,6 +2,8 @@ package com.allclear.tastytrack.domain.user.service;
 
 import com.allclear.tastytrack.domain.user.dto.LoginRequest;
 import com.allclear.tastytrack.domain.user.dto.UserCreateRequest;
+import com.allclear.tastytrack.domain.user.dto.UserInfo;
+import com.allclear.tastytrack.domain.user.dto.UserUpdateRequest;
 import com.allclear.tastytrack.domain.user.entity.User;
 import com.allclear.tastytrack.domain.user.repository.UserRepository;
 import com.allclear.tastytrack.global.exception.CustomException;
@@ -13,6 +15,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpHeaders;
 import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -38,6 +42,7 @@ class UserServiceImplTest {
                 .password("testPassword")
                 .lon(127.345)
                 .lat(35.492)
+                .lunchRecommendYn(false)
                 .build();
 
         userRepository.save(user);
@@ -90,15 +95,24 @@ class UserServiceImplTest {
     }
 
     @Test
+    @DisplayName("회원정보를 수정합니다.")
     void updateUserInfo() {
+        // given
+        UserUpdateRequest userUpdateRequest = UserUpdateRequest.builder()
+                .lon(122.34)
+                .lat(26.42)
+                .lunchRecommendYn(true)
+                .build();
 
+        // when
+        UserInfo user = userService.updateUserInfo("testUser", userUpdateRequest);
+
+        User testUser = userRepository.findByUsername(user.getUsername()).orElseThrow(
+                () -> new CustomException(ErrorCode.USER_NOT_EXIST)
+        );
+
+        // then
+        assertEquals(true, testUser.isLunchRecommendYn());
     }
-
-    @Test
-    void getUserInfo() {
-
-    }
-
-
 
 }


### PR DESCRIPTION
## 📌 작업 내용 (필수)
- Use의 Id 값 타입을 Long에서 int로 수정하였습니다. (낭비되는 메모리 고려)
- 로그인 기능 시 발생하는 에러 수정하였습니다.
- 회원가입, 로그인 시 테스트 케이스 추가하였습니다.
- accessToken과 refreshToken 발급 테스트하였습니다.
- 회원 정보 조회 controller 테스트 하였습니다.

<br/>

## 🌱 반영 브랜치
- test/#TT-54-user-test -> dev
- close #55 

<br/>

## 🔥트러블슈팅
- 유저의 토큰 검증을 위해 UserDetailsImpl 클래스의 객체를 생성해 유저의 정보를 가져와야 한다고 생각했습니다.
- 하지만 UserDetailsImpl 클래스가 record로 정의되어 있어 객체의 상태를 변경할 수 없었고, 생성자를 추가할 수 없었습니다.

``` Non-canonical record constructor must delegate to another constructor ```

- 이렇게 UserDetailsImpl을 MockHttpServletRequestBuilder의 principal 메서드에 직접 사용할 수 없는 경우, 다른 방법으로 테스트를 진행해야 했고, 그 중 Authentication 객체를 Mocking하여 MockHttpServletRequestBuilder에 전달하는 방법을 사용했습니다.

<img width="1165" alt="image" src="https://github.com/user-attachments/assets/401e5a78-c078-4e90-bdf9-e108e93b470a">

