### PR TITLE
[Fix] 위도 경도 타입 변환 과정에서 발생한 오류 수정

### DIFF
--- a/src/main/java/com/allclear/tastytrack/domain/restaurant/service/DataProcessingService.java
+++ b/src/main/java/com/allclear/tastytrack/domain/restaurant/service/DataProcessingService.java
@@ -77,6 +77,9 @@ public class DataProcessingService {
      */
     private Restaurant getRestaurantBuilder(RawRestaurant rawRestaurant) {
 
+        Double lon = rawRestaurant.getLon() != null ? Double.valueOf(rawRestaurant.getLon()) : null;
+        Double lat = rawRestaurant.getLat() != null ? Double.valueOf(rawRestaurant.getLat()) : null;
+
         return Restaurant.builder()
                 .code(rawRestaurant.getMgtno())
                 .name(rawRestaurant.getBplcnm())
@@ -84,8 +87,8 @@ public class DataProcessingService {
                 .status(rawRestaurant.getDtlstategbn())
                 .oldAddress(rawRestaurant.getSitewhladdr())
                 .newAddress(rawRestaurant.getRdnwhladdr())
-                .lon(Double.valueOf(rawRestaurant.getLon()))
-                .lat(Double.valueOf(rawRestaurant.getLat()))
+                .lon(lon)
+                .lat(lat)
                 .lastUpdatedAt(parseLastmodts(rawRestaurant.getLastmodts()))
                 .build();
     }
@@ -99,15 +102,11 @@ public class DataProcessingService {
     private void saveRestaurantsFromRawRestaurants(List<RawRestaurant> rawRestaurantList) throws Exception {
 
         for (RawRestaurant rawRestaurant : rawRestaurantList) {
-            // 도로명주소가 없는 데이터는 일단 제외
-            if (rawRestaurant.getRdnwhladdr().isEmpty()) continue;
 
             // 위도, 경도 값이 누락된 데이터 주입
-            if (rawRestaurant.getLon().isEmpty()) {
-                Coordinate coordinate = coordinateService.getCoordinate(rawRestaurant.getRdnwhladdr());
-                rawRestaurant.setLon(coordinate.getLon());
-                rawRestaurant.setLat(coordinate.getLat());
-            }
+            Coordinate coordinate = coordinateService.getCoordinate(rawRestaurant.getRdnwhladdr());
+            rawRestaurant.setLon(coordinate.getLon());
+            rawRestaurant.setLat(coordinate.getLat());
 
             // 가공 테이블에서 동일한 mgtno(code) 값을 가진 데이터를 조회
             Restaurant existingRestaurant = restaurantRepository.findByCode(rawRestaurant.getMgtno());


### PR DESCRIPTION
## 📌 작업 내용 (필수)
- 위도 경도의 타입 변환 과정에서 발생한 오류 수정하였습니다.

<br/>

## 🌱 반영 브랜치
- #feat/TT-47-geo-data-collection
- close #41 

<br/>

## 🔥 트러블 슈팅 (선택)
### 상황 요약

맛집 원본 데이터에 누락된 위도와 경도 값을 추가하기 위해, 해당 데이터의 주소를 활용하여 주소 검색 OpenAPI를 호출했습니다. 그러나 맛집 원본 데이터는 중부원점TM 좌표계로 저장된 반면, 주소 검색 OpenAPI는 WGS84 좌표계를 사용하고 있어, 두 좌표계의 불일치 문제가 발생했습니다. 이를 해결하기 위해 모든 위도·경도 값을 WGS84 좌표계로 통일하고자 했습니다.

### 문제 발생

코드를 수정하여 맛집 원본 데이터를 가공 테이블에 저장하는 과정에서 다음과 같은 오류가 발생했습니다:

```json
{
    "message": "Cannot invoke \"String.trim()\" because \"in\" is null",
    "httpStatus": "BAD_REQUEST"
}
```

![image](https://github.com/user-attachments/assets/820503f0-fbf1-4f89-b18f-28b98a3e6341)

![image](https://github.com/user-attachments/assets/384e590b-1e5b-4576-aab6-a39d6327de0c)

이 오류는 Java에서 `String.trim()` 메서드를 호출하려 할 때, 해당 객체가 `null`일 경우 발생합니다. 하지만, 코드 내에서 `in`이라는 변수를 사용하지 않았기 때문에 다른 원인을 찾아야 했습니다.

### 원인 분석

조사를 통해, 코드에서 직접적으로 `trim()`을 호출하지 않았더라도, `Double.parseDouble()` 같은 메서드가 내부적으로 `trim()`을 사용할 수 있다는 사실을 알게 되었습니다. 실제로, 위도·경도 값을 `Double` 타입으로 변환하는 과정에서 오류가 발생한 것으로 보였습니다.

역추적을 통해 확인해본 결과, 문제의 원인은 **맛집 원본 데이터의 지번 주소에 오타가 있었기 때문**이었습니다. 잘못된 주소로 OpenAPI를 호출한 결과, 위도·경도 값이 `null`로 반환되었고, 이 값을 `Double`로 변환하려는 시도에서 오류가 발생했습니다.

빌당 (X) → 빌딩 (O)

<img width="336" alt="Screenshot 2024-08-31 at 16 22 52" src="https://github.com/user-attachments/assets/fadd7446-cb43-43c1-99e3-5330cdac9881">

### 해결 방법

1. **도로명 주소 우선 사용**: 데이터의 신뢰성이 낮은 지번 주소 대신, **도로명 주소**를 활용하여 주소 검색 OpenAPI를 호출하도록 수정했습니다.
2. **지번 주소의 보완적 활용**: 만약 도로명 주소가 존재하지 않는 경우, 그때에 한해 **지번 주소**를 사용하도록 했습니다.
3. **Null 값 처리**: 조회 결과로 얻은 위도·경도 값이 `null`인 경우, 해당 데이터를 맛집 가공 테이블에 저장하지 않도록 했습니다.