### PR TITLE
[Refactor] 사용자 관련 API 보완

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,61 +1,66 @@
 plugins {
-	id 'java'
-	id 'org.springframework.boot' version '3.3.3'
-	id 'io.spring.dependency-management' version '1.1.6'
+    id 'java'
+    id 'org.springframework.boot' version '3.3.3'
+    id 'io.spring.dependency-management' version '1.1.6'
 }
 
 group = 'com.allclear'
 version = '0.0.1-SNAPSHOT'
 
 java {
-	toolchain {
-		languageVersion = JavaLanguageVersion.of(17)
-	}
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
 }
 
 configurations {
-	compileOnly {
-		extendsFrom annotationProcessor
-	}
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-security'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	compileOnly 'org.projectlombok:lombok'
-	runtimeOnly 'com.mysql:mysql-connector-j'
-	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testImplementation 'org.springframework.security:spring-security-test'
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    // Spring Boot 스타터 의존성
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
 
-	// validation
-	implementation 'jakarta.validation:jakarta.validation-api:3.0.2'
+    // Lombok 의존성 (컴파일 타임 어노테이션 처리)
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
 
-	// jwt
-	implementation 'com.auth0:java-jwt:3.18.2'
+    // 데이터베이스 연결
+    runtimeOnly 'com.mysql:mysql-connector-j'
 
-	// redis
-	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    // 테스트 관련 의존성
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.security:spring-security-test'
 
-	// spring_security
-	implementation 'org.springframework.boot:spring-boot-starter-security'
-	testImplementation 'org.springframework.security:spring-security-test'
+    // JUnit 5 런처
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
-	// swagger
-	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
+    // Validation API
+    implementation 'jakarta.validation:jakarta.validation-api:3.0.2'
+
+    // JWT (JSON Web Token) 라이브러리
+    implementation 'com.auth0:java-jwt:3.18.2'
+
+    // Redis 관련 의존성
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+    // Swagger (API 문서화)
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
 
 }
 
 tasks.named('test') {
-	useJUnitPlatform()
+    useJUnitPlatform()
 }
 
 tasks.withType(Test) {
-	enabled = false
+    enabled = false
 }

--- a/src/main/java/com/allclear/tastytrack/domain/auth/UserAuthImpl.java
+++ b/src/main/java/com/allclear/tastytrack/domain/auth/UserAuthImpl.java
@@ -9,20 +9,41 @@ import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
-public class UserAuthImpl implements UserAuth{
+public class UserAuthImpl implements UserAuth {
     private final JwtTokenUtils jwtTokenUtils;
     private final RefreshTokenManager refreshTokenManager;
 
+    /**
+     * JwtToken 생성합니다.
+     * 작성자 : 오예령
+     *
+     * @param user 유저 객체
+     * @return 해당 유저의 accessToken 반환합니다.
+     */
     @Override
     public String getToken(User user) {
         return jwtTokenUtils.generateJwtToken(user.getUsername());
     }
 
+    /**
+     * RefreshToken을 생성하고 Redis에 저장합니다.
+     * 작성자: 오예령
+     *
+     * @param user 유저 객체
+     * @return 해당 유저의 refreshToken을 반환합니다.
+     */
     @Override
     public String saveRefreshTokenToRedis(User user){
         return refreshTokenManager.saveRefreshToken(user.getUsername());
     }
 
+    /**
+     * 유저의 헤더에 accessToken과 refreshToken을 담아 반환합니다.
+     * 작성자: 오예령
+     *
+     * @param user 유저 객체
+     * @return 토큰이 담긴 헤더 반환합니다.
+     */
     @Override
     public HttpHeaders generateHeaderTokens(User user) {
         HttpHeaders headers = new HttpHeaders();  // 여기서 HttpHeaders 객체를 생성

--- a/src/main/java/com/allclear/tastytrack/domain/auth/UserDetailsServiceImpl.java
+++ b/src/main/java/com/allclear/tastytrack/domain/auth/UserDetailsServiceImpl.java
@@ -12,10 +12,12 @@ import org.springframework.stereotype.Service;
 @Service
 @RequiredArgsConstructor
 public class UserDetailsServiceImpl {
+
     private final UserRepository userRepository;
 
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
-        User user =  userRepository.findByUsername(username)
+
+        User user = userRepository.findByUsername(username)
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_EXIST));
 
         return new UserDetailsImpl(user);

--- a/src/main/java/com/allclear/tastytrack/domain/auth/UserDetailsServiceImpl.java
+++ b/src/main/java/com/allclear/tastytrack/domain/auth/UserDetailsServiceImpl.java
@@ -2,8 +2,6 @@ package com.allclear.tastytrack.domain.auth;
 
 import com.allclear.tastytrack.domain.user.entity.User;
 import com.allclear.tastytrack.domain.user.repository.UserRepository;
-import com.allclear.tastytrack.global.exception.CustomException;
-import com.allclear.tastytrack.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
@@ -18,7 +16,7 @@ public class UserDetailsServiceImpl {
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
 
         User user = userRepository.findByUsername(username)
-                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_EXIST));
+                .orElseThrow(() -> new UsernameNotFoundException("가입되지 않은 아이디입니다."));
 
         return new UserDetailsImpl(user);
     }

--- a/src/main/java/com/allclear/tastytrack/domain/auth/token/JwtTokenUtils.java
+++ b/src/main/java/com/allclear/tastytrack/domain/auth/token/JwtTokenUtils.java
@@ -22,7 +22,16 @@ public class JwtTokenUtils {
     @Value("${jwt.secretkey}")
     String JWT_SECRET;
 
+    /**
+     * JwtToken을 생성합니다.
+     * 생성된 토큰에는 payload, 토큰 만료일, 그리고 signature가 포함됩니다.
+     * 작성자: 오예령
+     *
+     * @param username 유저 계정명
+     * @return 해당 유저의 accessToken을 반환합니다.
+     */
     public String generateJwtToken(String username) {
+
         String token;
 
         token = JWT.create()
@@ -33,14 +42,32 @@ public class JwtTokenUtils {
         return token;
     }
 
+    /**
+     * 유저 계정명을 포함하는 claims 맵을 생성합니다.
+     * 작성자 : 오예령
+     *
+     * @param username 유저 계정명
+     * @return 유저 계정명이 포함된 key-value 형식의 claims 맵을 반환
+     */
     private Map<String, Object> createClaims(String username) {
+
         Map<String, Object> claims = new HashMap<>();
         claims.put(CLAIM_USERNAME, username);
 
         return claims;
     }
 
+    /**
+     * HMAC256 형식의 알고리즘을 생성합니다.
+     * 생성된 알고리즘은 JWT의 서명(Signature) 생성에 사용됩니다.
+     * 작성자: 오예령
+     *
+     * @param secretKey JWT 서명에 사용할 secret key
+     * @return HMAC256 알고리즘을 반환합니다.
+     */
     private static Algorithm generateAlgorithm(String secretKey) {
+
         return Algorithm.HMAC256(secretKey.getBytes());
     }
+
 }

--- a/src/main/java/com/allclear/tastytrack/domain/auth/token/RefreshToken.java
+++ b/src/main/java/com/allclear/tastytrack/domain/auth/token/RefreshToken.java
@@ -1,17 +1,5 @@
 package com.allclear.tastytrack.domain.auth.token;
 
-import lombok.Getter;
-
-@Getter
-public class RefreshToken {
-
-    private final String refreshToken;
-    private final String username;
-
-    public RefreshToken(final String refreshToken, final String username) {
-
-        this.refreshToken = refreshToken;
-        this.username = username;
-    }
+public record RefreshToken(String refreshToken, String username) {
 
 }

--- a/src/main/java/com/allclear/tastytrack/domain/auth/token/RefreshTokenCleanupScheduler.java
+++ b/src/main/java/com/allclear/tastytrack/domain/auth/token/RefreshTokenCleanupScheduler.java
@@ -1,0 +1,28 @@
+package com.allclear.tastytrack.domain.auth.token;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+
+@Component
+@RequiredArgsConstructor
+public class RefreshTokenCleanupScheduler {
+
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    /**
+     * 주기적으로 만료된 RefreshToken을 삭제합니다.
+     * 매일 자정에 실행되도록 설정합니다.
+     * 작성자 : 오예령
+     */
+    @Scheduled(cron = "0 0 0 * * *") // 매일 자정에 실행
+    public void cleanUpExpiredTokens() {
+
+        LocalDateTime now = LocalDateTime.now();
+        // 만료된 토큰을 찾고 삭제합니다.
+        refreshTokenRepository.deleteExpiredTokens(now);
+    }
+
+}

--- a/src/main/java/com/allclear/tastytrack/domain/auth/token/RefreshTokenManager.java
+++ b/src/main/java/com/allclear/tastytrack/domain/auth/token/RefreshTokenManager.java
@@ -2,7 +2,6 @@ package com.allclear.tastytrack.domain.auth.token;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.stereotype.Component;
 
 import java.security.SecureRandom;
@@ -12,11 +11,19 @@ import java.util.Base64;
 @RequiredArgsConstructor
 @Slf4j
 public class RefreshTokenManager {
+    
+    private final static int TOKEN_LENGTH = 32; // Refresh Token의 길이를 설정
+    private final SecureRandom secureRandom; // 난수 생성을 위한 SecureRandom 인스턴스
+    private final RefreshTokenRepository refreshTokenRepository; // RefreshToken을 저장할 Repository
 
-    private final static int TOKEN_LENGTH = 32;
-    private final SecureRandom secureRandom;
-    private final RefreshTokenRepository refreshTokenRepository;
 
+    /**
+     * RefreshToken을 생성합니다.
+     * TOKEN_LENGTH 길이의 난수를 생성하고, 이를 Base64 URL 형식으로 인코딩하여 반환합니다.
+     * 작성자 : 오예령
+     *
+     * @return 생성된 RefreshToken 반환합니다.
+     */
     public String refreshTokenGenerator() {
 
         byte[] randomBytes = new byte[TOKEN_LENGTH];
@@ -25,16 +32,31 @@ public class RefreshTokenManager {
         return Base64.getUrlEncoder().withoutPadding().encodeToString(randomBytes);
     }
 
+    /**
+     * 유저의 계정명으로 생성된 RefreshToken을 저장합니다.
+     * 작성자 : 오예령
+     *
+     * @param username 유저 계정명
+     * @return 저장된 RefreshToken을 반환합니다.
+     */
     public String saveRefreshToken(final String username) {
 
+        // 새로운 Refresh Token을 생성
         String refreshToken = refreshTokenGenerator();
         log.info("generated RefreshToken = {} ", refreshToken);
+
+        // 생성된 토큰이 이미 존재하는지 확인
         if (refreshTokenRepository.findByUsername(refreshToken).isPresent()) {
-            saveRefreshToken(username);
+            // 토큰이 이미 존재하면, 새로운 토큰을 재귀적으로 생성
+            return saveRefreshToken(username);
         } else {
+            // 토큰이 존재하지 않는 경우 해당 유저의 이름으로 새 토큰을 발급해 저장
             refreshTokenRepository.save(new RefreshToken(refreshToken, username));
         }
+
+        // 최종적으로 저장된 RefreshToken을 반환
         return refreshToken;
     }
+
 
 }

--- a/src/main/java/com/allclear/tastytrack/domain/auth/token/RefreshTokenRepository.java
+++ b/src/main/java/com/allclear/tastytrack/domain/auth/token/RefreshTokenRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.stereotype.Component;
 
+import java.time.LocalDateTime;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
@@ -15,14 +16,28 @@ public class RefreshTokenRepository {
 
     private final RedisTemplate<String, String> redisTemplate;
 
+    private final long TOKEN_EXPIRY_DAYS = 90L; // 만기일 설정
+
+    /**
+     * RefreshToken을 저장합니다.
+     * 작성자 : 오예령
+     *
+     * @param refreshToken 저장할 RefreshToken
+     */
     public void save(final RefreshToken refreshToken) {
 
         ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();
-        valueOperations.set(refreshToken.getRefreshToken(), refreshToken.getUsername());
-        redisTemplate.expire(refreshToken.getRefreshToken(), 90L, TimeUnit.DAYS);
+        valueOperations.set(refreshToken.refreshToken(), refreshToken.username());
+        redisTemplate.expire(refreshToken.refreshToken(), TOKEN_EXPIRY_DAYS, TimeUnit.DAYS); // TTL 설정
     }
 
-
+    /**
+     * RefreshToken을 통해 유저 정보를 찾습니다.
+     * 작성자 : 오예령
+     *
+     * @param refreshToken 찾을 RefreshToken
+     * @return RefreshToken과 관련된 유저 정보를 담은 Optional
+     */
     public Optional<RefreshToken> findByUsername(final String refreshToken) {
 
         ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();
@@ -35,4 +50,15 @@ public class RefreshTokenRepository {
         return Optional.of(new RefreshToken(refreshToken, username));
     }
 
+    /**
+     * 만료된 RefreshToken을 삭제합니다.
+     * 작성자 : 오예령
+     *
+     * @param now 현재 시간
+     */
+    public void deleteExpiredTokens(LocalDateTime now) {
+
+    }
+
 }
+

--- a/src/main/java/com/allclear/tastytrack/domain/auth/token/TokenProvider.java
+++ b/src/main/java/com/allclear/tastytrack/domain/auth/token/TokenProvider.java
@@ -33,33 +33,61 @@ import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 public class TokenProvider {
 
     @Value("${jwt.secretkey}")
-    String JWT_SECRET;
+    private String JWT_SECRET;
+
     private final Logger logger = LoggerFactory.getLogger(TokenProvider.class);
     private final UserDetailsServiceImpl userDetailsService;
 
-    private static final String TOKEN_PREFIX = "Bearer ";
+    private static final String TOKEN_PREFIX = "Bearer "; // JWT 토큰의 접두사
 
+    /**
+     * HTTP 요청에서 JWT 토큰을 추출합니다.
+     * 작성자 : 오예령
+     *
+     * @param request HTTP 요청 객체
+     * @return JWT 토큰 문자열 반환
+     */
     public String resolveToken(HttpServletRequest request) {
 
         String bearerToken = request.getHeader("Authorization");
         log.info("token : {}", bearerToken);
 
+        // Authorization 헤더가 존재하고, "Bearer "로 시작하는 경우 토큰을 추출
         if (bearerToken != null && bearerToken.startsWith(TOKEN_PREFIX)) {
             return bearerToken.substring(TOKEN_PREFIX.length());
         }
         return null;
     }
 
+    /**
+     * JWT 토큰을 기반으로 인증 정보를 생성합니다.
+     * 작성자 : 오예령
+     *
+     * @param token JWT 토큰
+     * @param response HTTP 응답 객체
+     * @return Authentication 객체 반환
+     * @throws IOException 예외 발생 시
+     */
     public Authentication getAuthentication(String token, HttpServletResponse response) throws IOException {
 
+        // 토큰에서 사용자 정보를 추출하여 UserDetails를 로드
         UserDetails userDetails = userDetailsService.loadUserByUsername(decodeUsername(token, response));
         return new UsernamePasswordAuthenticationToken(
                 userDetails, "", userDetails.getAuthorities());
     }
 
-    // 토큰에서 회원 정보 추출
+    /**
+     * JWT 토큰에서 사용자 계정명을 추출합니다.
+     * 작성자 : 오예령
+     *
+     * @param token JWT 토큰
+     * @param response HTTP 응답 객체
+     * @return 사용자 계정명 반환
+     * @throws IOException 예외 발생 시
+     */
     public String decodeUsername(String token, HttpServletResponse response) throws IOException {
 
+        // 토큰의 유효성을 검사하고, 유효한 경우 사용자 계정명을 추출
         DecodedJWT decodedJWT = isValidToken(token, response)
                 .orElseThrow(() -> new IllegalArgumentException("유효한 토큰이 아닙니다."));
 
@@ -68,32 +96,55 @@ public class TokenProvider {
                 .asString();
     }
 
-    // 토큰 유효성 검사
+    /**
+     * JWT 토큰의 유효성을 검사합니다.
+     * 작성자 : 오예령
+     *
+     * @param token JWT 토큰
+     * @param response HTTP 응답 객체
+     * @return 유효한 토큰을 DecodedJWT로 반환, 유효하지 않으면 Optional.empty()
+     * @throws IOException 예외 발생 시
+     */
     public Optional<DecodedJWT> isValidToken(String token, HttpServletResponse response) throws IOException {
 
         DecodedJWT jwt = null;
         try {
+            // JWT 토큰 검증을 위한 JWTVerifier 생성
             JWTVerifier verifier = JWT
                     .require(generateAlgorithm(JWT_SECRET))
                     .build();
             jwt = verifier.verify(token);
         } catch (TokenExpiredException e) {
+            // 토큰이 만료된 경우 에러 처리
             logger.error(e.getMessage());
             tokenExpired(response);
         }
         return Optional.ofNullable(jwt);
     }
 
-    // 만료된 토큰인 경우 error 처리
+    /**
+     * 만료된 토큰에 대해 에러 응답을 생성합니다.
+     * 작성자 : 오예령
+     *
+     * @param response HTTP 응답 객체
+     * @throws IOException 예외 발생 시
+     */
     public void tokenExpired(HttpServletResponse response) throws IOException {
 
         response.setStatus(SC_UNAUTHORIZED);
         response.setContentType(APPLICATION_JSON_VALUE);
         response.setCharacterEncoding("utf-8");
-        ErrorResponse errorResponse = new ErrorResponse(HttpStatus.UNAUTHORIZED, "만료된 토큰입니다!");
+        ErrorResponse errorResponse = new ErrorResponse(HttpStatus.UNAUTHORIZED, "만료된 토큰입니다.");
         new ObjectMapper().writeValue(response.getWriter(), errorResponse);
     }
 
+    /**
+     * HMAC256 알고리즘을 생성합니다.
+     * 작성자 : 오예령
+     *
+     * @param secretKey JWT 비밀 키
+     * @return HMAC256 알고리즘
+     */
     private static Algorithm generateAlgorithm(String secretKey) {
 
         return Algorithm.HMAC256(secretKey.getBytes());

--- a/src/main/java/com/allclear/tastytrack/domain/user/controller/TokenController.java
+++ b/src/main/java/com/allclear/tastytrack/domain/user/controller/TokenController.java
@@ -1,0 +1,23 @@
+package com.allclear.tastytrack.domain.user.controller;
+
+import com.allclear.tastytrack.domain.auth.token.RefreshTokenManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class TokenController {
+
+    private final RefreshTokenManager refreshTokenManager;
+
+    @PostMapping("/api/refresh")
+    public ResponseEntity<?> refreshAccessToken(@RequestHeader("RefreshToken") String refreshToken) {
+
+        String newAccessToken = refreshTokenManager.refreshAccessToken(refreshToken);
+        return ResponseEntity.ok(newAccessToken);
+    }
+
+}

--- a/src/main/java/com/allclear/tastytrack/global/config/WebSecurityConfig.java
+++ b/src/main/java/com/allclear/tastytrack/global/config/WebSecurityConfig.java
@@ -58,6 +58,7 @@ public class WebSecurityConfig {
                         .requestMatchers(HttpMethod.POST, ("/api/users/**")).permitAll()
                         .requestMatchers(
                                 "/api/restaurants/**",
+                                "/api/refresh",
                                 "/api/regions/**",
                                 "/h2-console/**",
                                 "/swagger-ui/**",

--- a/src/test/java/com/allclear/tastytrack/domain/user/service/TokenVerifyTest.java
+++ b/src/test/java/com/allclear/tastytrack/domain/user/service/TokenVerifyTest.java
@@ -74,7 +74,7 @@ public class TokenVerifyTest {
         RefreshToken refreshToken = refreshTokenRepository.findByUsername(key).orElseThrow(
                 () -> new NullPointerException("해당 값이 존재하지 않습니다.")
         );
-        assertThat(refreshToken.getUsername()).isEqualTo("testUser");
+        assertThat(refreshToken.username()).isEqualTo("testUser");
     }
 
 }


### PR DESCRIPTION
## 📌 작업 내용 (필수)
- 토큰 생성 및 검증하는 메서드에 주석 추가하였습니다.
- 주기적으로 만료된 RefreshToken 삭제하는 로직 추가하였습니다.
- RefreshToken 클래스 record 타입 변경하였습니다.
- AccessToken 만료된 경우 RefreshToken으로 재발급하는 API 추가하였습니다.

<br/>

## 🌱 반영 브랜치
- refactor/#TT-63-user-token -> dev
- close #73 
