### PR TITLE
[Pref] 맛집 상세정보 조회에 redis cache 적용

### DIFF
--- a/src/main/java/com/allclear/tastytrack/TastytrackApplication.java
+++ b/src/main/java/com/allclear/tastytrack/TastytrackApplication.java
@@ -2,6 +2,7 @@ package com.allclear.tastytrack;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @EnableScheduling

--- a/src/main/java/com/allclear/tastytrack/domain/auth/JwtAuthenticationFilter.java
+++ b/src/main/java/com/allclear/tastytrack/domain/auth/JwtAuthenticationFilter.java
@@ -1,16 +1,18 @@
 package com.allclear.tastytrack.domain.auth;
 
+import java.io.IOException;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
 import com.allclear.tastytrack.domain.auth.token.TokenProvider;
+
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.web.filter.OncePerRequestFilter;
-
-import java.io.IOException;
 
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
@@ -18,7 +20,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private final TokenProvider tokenProvider;
 
     @Override
-    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+            FilterChain filterChain) throws ServletException, IOException {
         // header에서 token을 받아온다
         String token = tokenProvider.resolveToken(request);
 

--- a/src/main/java/com/allclear/tastytrack/domain/restaurant/service/RestaurantService.java
+++ b/src/main/java/com/allclear/tastytrack/domain/restaurant/service/RestaurantService.java
@@ -3,7 +3,7 @@ package com.allclear.tastytrack.domain.restaurant.service;
 import java.util.List;
 
 import com.allclear.tastytrack.domain.restaurant.dto.RestaurantByUserLocation;
-import com.allclear.tastytrack.domain.restaurant.dto.RestaurantListRequest;
+import com.allclear.tastytrack.domain.restaurant.dto.RestaurantDetail;
 import com.allclear.tastytrack.domain.restaurant.entity.Restaurant;
 import com.allclear.tastytrack.domain.review.dto.ReviewRequest;
 import com.allclear.tastytrack.domain.user.dto.UserLocationInfo;
@@ -21,5 +21,9 @@ public interface RestaurantService {
     List<Restaurant> getRestaurantByUserLocation(UserLocationInfo userLocationInfo);
 
     List<RestaurantByUserLocation> createListRestaurantByUserLocation(List<Restaurant> restaurants);
+
+    RestaurantDetail checkRedisCache(int id);
+
+    void saveCache(int id, RestaurantDetail restaurantDetail1);
 
 }

--- a/src/main/java/com/allclear/tastytrack/domain/restaurant/service/RestaurantServiceImpl.java
+++ b/src/main/java/com/allclear/tastytrack/domain/restaurant/service/RestaurantServiceImpl.java
@@ -13,6 +13,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.allclear.tastytrack.domain.region.entity.Region;
 import com.allclear.tastytrack.domain.region.repository.RegionRepository;
 import com.allclear.tastytrack.domain.restaurant.dto.RestaurantByUserLocation;
+import com.allclear.tastytrack.domain.restaurant.dto.RestaurantDetail;
 import com.allclear.tastytrack.domain.restaurant.dto.RestaurantListRequest;
 import com.allclear.tastytrack.domain.restaurant.entity.Restaurant;
 import com.allclear.tastytrack.domain.restaurant.repository.RestaurantRepository;
@@ -22,6 +23,7 @@ import com.allclear.tastytrack.domain.user.dto.UserLocationInfo;
 import com.allclear.tastytrack.domain.user.enums.Coordinate;
 import com.allclear.tastytrack.global.exception.CustomException;
 import com.allclear.tastytrack.global.exception.ErrorCode;
+import com.allclear.tastytrack.global.util.RedisUtil;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -35,6 +37,8 @@ public class RestaurantServiceImpl implements RestaurantService {
     private final RestaurantRepository restaurantRepository;
     private final ReviewRepository reviewRepository;
     private final RegionRepository regionRepository;
+
+    private final RedisUtil redisUtil;
 
     @Override
     public Restaurant getRestaurantById(int id, int deletedYn) {
@@ -135,6 +139,24 @@ public class RestaurantServiceImpl implements RestaurantService {
 
 
         return complListRestaurantByUserLocation.join();
+    }
+
+    @Override
+    public RestaurantDetail checkRedisCache(int id) {
+
+        RestaurantDetail restaurantDetail1 = redisUtil.getCache(id);
+
+        if (restaurantDetail1 != null) {
+            log.info("data in cache!");
+        }
+
+        return restaurantDetail1;
+    }
+
+    @Override
+    public void saveCache(int id, RestaurantDetail restaurantDetail1) {
+
+        redisUtil.setCache(id, restaurantDetail1);
     }
 
     /**

--- a/src/main/java/com/allclear/tastytrack/global/config/RedsiConfig.java
+++ b/src/main/java/com/allclear/tastytrack/global/config/RedsiConfig.java
@@ -1,0 +1,37 @@
+package com.allclear.tastytrack.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedsiConfig {
+
+    @Value(("${REDIS_PASSWORD}"))
+    private String password;
+
+    @Bean
+    public RedisConnectionFactory connectionFactory() {
+
+        RedisStandaloneConfiguration redisConfiguration = new RedisStandaloneConfiguration();
+        redisConfiguration.setPassword(password);
+        return new LettuceConnectionFactory(redisConfiguration);
+    }
+
+    @Bean
+    RedisTemplate<String, Object> redisTemplate() {
+
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+        template.setConnectionFactory(connectionFactory());
+        return template;
+    }
+
+}

--- a/src/main/java/com/allclear/tastytrack/global/util/RedisUtil.java
+++ b/src/main/java/com/allclear/tastytrack/global/util/RedisUtil.java
@@ -1,0 +1,46 @@
+package com.allclear.tastytrack.global.util;
+
+import java.util.concurrent.TimeUnit;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import com.allclear.tastytrack.domain.restaurant.dto.RestaurantDetail;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class RedisUtil {
+
+    private final RedisTemplate<String, Object> redisTp;
+
+    public RestaurantDetail getCache(int key) {
+
+        String keyStr = changeString(key);
+
+        RestaurantDetail value = (RestaurantDetail)redisTp.opsForValue().get(keyStr);
+
+        if (value == null) {
+            log.info("cache miss!");
+        }
+
+        return value;
+    }
+
+    public void setCache(int key, RestaurantDetail restaurantDetail) {
+
+        String keyStr = changeString(key);
+
+        redisTp.opsForValue().set(keyStr, restaurantDetail, 600, TimeUnit.SECONDS);
+        log.info("save cache");
+    }
+
+    private String changeString(int key) {
+
+        return String.valueOf(key);
+    }
+
+}

--- a/src/test/java/com/allclear/tastytrack/domain/restaurant/controller/RestaurantControllerTest.java
+++ b/src/test/java/com/allclear/tastytrack/domain/restaurant/controller/RestaurantControllerTest.java
@@ -17,7 +17,6 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.test.context.ActiveProfiles;
 
 import com.allclear.tastytrack.domain.auth.token.JwtTokenUtils;
 import com.allclear.tastytrack.domain.restaurant.dto.RestaurantByUserLocation;
@@ -28,7 +27,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@ActiveProfiles("test")
+// @ActiveProfiles("test")
 public class RestaurantControllerTest {
 
     @Autowired
@@ -49,7 +48,7 @@ public class RestaurantControllerTest {
                 .lat(14128052.4047183)
                 .lon(4526216.5022505).build();
         HttpEntity<UserCreateRequest> entity = new HttpEntity<>(userCreateRequest);
-        testRestTemplate.exchange("/api/users", HttpMethod.POST, entity, String.class);
+        // testRestTemplate.exchange("/api/users", HttpMethod.POST, entity, String.class);
 
         String token = jwtTokenUtils.generateJwtToken(userCreateRequest.getUsername());
         httpHeaders = new HttpHeaders();

--- a/src/test/java/com/allclear/tastytrack/domain/review/controller/ReviewControllerTest.java
+++ b/src/test/java/com/allclear/tastytrack/domain/review/controller/ReviewControllerTest.java
@@ -13,7 +13,6 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.test.context.ActiveProfiles;
 
 import com.allclear.tastytrack.domain.auth.token.JwtTokenUtils;
 import com.allclear.tastytrack.domain.restaurant.dto.RestaurantDetail;
@@ -21,7 +20,7 @@ import com.allclear.tastytrack.domain.review.dto.ReviewRequest;
 import com.allclear.tastytrack.domain.user.dto.UserCreateRequest;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@ActiveProfiles("test")
+// @ActiveProfiles("test")
 public class ReviewControllerTest {
 
     @Autowired


### PR DESCRIPTION
## 📌 작업 내용 (필수)
- 맛집 상세정보 조회 api 호출 시 redis cache 확인 후 해당 데이터가 cache에 저장되어 있으면 반환하도록 개선했습니다.

![스크린샷 2024-09-03 오후 11 43 54](https://github.com/user-attachments/assets/4351dfa5-22c0-4f56-9ce9-59370abfe38b)
- redis cache에 데이터가 존재하지 않을 때 속도

![스크린샷 2024-09-03 오후 11 44 00](https://github.com/user-attachments/assets/a5701772-b71b-48d5-a295-fdf2559aba81)
- redis cache에 데이터가 존재할 때 속도

<br/>

## 🌱 반영 브랜치
- perf/#TT-13-restaurant-detail

<br/>

## 🔥 트러블 슈팅 (선택)
