### PR TITLE
[Refactor] 원본 맛집 전처리 시 도로명주소, 위도, 경도가 없고, 지번주소도 조회되지 않는 경우, 가공 맛집 저장에서 제외

### DIFF
--- a/src/main/java/com/allclear/tastytrack/domain/batch/config/BatchConfig.java
+++ b/src/main/java/com/allclear/tastytrack/domain/batch/config/BatchConfig.java
@@ -157,7 +157,7 @@ public class BatchConfig {
                 String addressToUse = item.getRdnwhladdr().isEmpty() ? item.getSitewhladdr() :
                         item.getRdnwhladdr();
 
-                log.info("{}번째 저장하려는 가공 맛집 : {}", item.getId(), item.getBplcnm());
+                log.info("{}번째 저장될 가공 맛집 : {}", item.getId(), item.getBplcnm());
 
                 Coordinate coordinateByRdnwhladder = coordinateService.getCoordinate(addressToUse);
 
@@ -168,13 +168,18 @@ public class BatchConfig {
 
                     item.setLon(coordinateBySitewhladdr.getLon());
                     item.setLat(coordinateBySitewhladdr.getLat());
+
+                    // 원본 맛집에 도로명주소, 위도, 경도가 없고, 지번주소도 잘못된 경우 가공 저장 제외
+                    if (item.getLat() == null) {
+                        log.info("{} 맛집은 도로명주소, 위도, 경도가 존재하지 않고, 지번주소가 조회되지 않아 저장에서 제외되었습니다. ", item.getBplcnm());
+                        return null;
+                    }
                 } else {
                     item.setLon(coordinateByRdnwhladder.getLon());
                     item.setLat(coordinateByRdnwhladder.getLat());
                 }
 
                 log.info("{} 맛집의 도로명주소 버전 위도 : {}, 경도 : {}", item.getBplcnm(), coordinateByRdnwhladder.getLon(), coordinateByRdnwhladder.getLat());
-
 
                 // 가공 테이블에서 동일한 mgtno(code) 값을 가진 데이터를 조회
                 Restaurant existingRestaurant = restaurantRepository.findByCode(item.getMgtno());
@@ -193,7 +198,7 @@ public class BatchConfig {
 
                         existingRestaurant.updateWithNewData(rawDataService.getRestaurantBuilder(item));
 
-                        log.info("업데이트된 원본 맛집 : {}", existingRestaurant.getName());
+                        log.info("업데이트된 가공 맛집 : {}", existingRestaurant.getName());
                         return existingRestaurant; // 업데이트할 가공 맛집 반환
                     }
                 } else {
@@ -203,7 +208,7 @@ public class BatchConfig {
                     try {
                         return restaurant; // 가공된 데이터 반환
                     } catch (DataIntegrityViolationException e) {
-                        log.error("관리번호 {} 저장 실패 : ", item.getMgtno(), e);
+                        log.error("관리번호 {} 가공 맛집 저장 실패 : ", item.getMgtno(), e);
                     }
                 }
 

--- a/src/main/java/com/allclear/tastytrack/domain/batch/controller/ApiController.java
+++ b/src/main/java/com/allclear/tastytrack/domain/batch/controller/ApiController.java
@@ -6,12 +6,12 @@ import org.springframework.batch.core.JobParametersBuilder;
 import org.springframework.batch.core.configuration.JobRegistry;
 import org.springframework.batch.core.launch.JobLauncher;
 import org.springframework.http.ResponseEntity;
-import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
-@Controller
+@RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/fetch")
 public class ApiController {

--- a/src/main/java/com/allclear/tastytrack/domain/batch/listener/JobCompletionNotificationListener.java
+++ b/src/main/java/com/allclear/tastytrack/domain/batch/listener/JobCompletionNotificationListener.java
@@ -1,0 +1,33 @@
+package com.allclear.tastytrack.domain.batch.listener;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.JobExecutionListener;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+
+@Slf4j
+@Component
+public class JobCompletionNotificationListener implements JobExecutionListener {
+
+    private LocalDateTime jobStartTime;
+    private LocalDateTime jobEndTime;
+
+    @Override
+    public void beforeJob(JobExecution jobExecution) {
+
+        jobStartTime = LocalDateTime.now();
+        log.info("배치 작업 '{}' 시작 시간: {}", jobExecution.getJobInstance().getJobName(), jobStartTime);
+    }
+
+    @Override
+    public void afterJob(JobExecution jobExecution) {
+
+        jobEndTime = LocalDateTime.now();
+        log.info("배치 작업 '{}' 종료 시간: {}", jobExecution.getJobInstance().getJobName(), jobEndTime);
+        log.info("배치 작업 '{}' 소요 시간: {} seconds", jobExecution.getJobInstance().getJobName(),
+                java.time.Duration.between(jobStartTime, jobEndTime).getSeconds());
+    }
+
+}

--- a/src/main/java/com/allclear/tastytrack/domain/batch/service/RawDataService.java
+++ b/src/main/java/com/allclear/tastytrack/domain/batch/service/RawDataService.java
@@ -9,7 +9,6 @@ import com.allclear.tastytrack.global.exception.ErrorCode;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestClientException;
@@ -22,7 +21,6 @@ import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 
-@Slf4j
 @Service
 @RequiredArgsConstructor
 public class RawDataService {
@@ -42,7 +40,6 @@ public class RawDataService {
     private String serviceName;  // 서비스명
 
     private static final int PAGE_SIZE = 100; // 1회 호출 시 응답받을 데이터 수
-    private static int counter = 0;
 
     /**
      * 공공데이터 API에서 맛집 데이터를 수집하여 원본 테이블에 저장하는 공통 로직을 처리하는 메서드입니다.
@@ -118,7 +115,6 @@ public class RawDataService {
                     jsonRows.add(getJsonRowsBuilder(raw));
                 }
             }
-//            log.info("JSON 응답 총 {}건 중 {}개가 원본 테이블에 저장 완료되었습니다.", totalCount, counter);
             return totalCount; // 전체 데이터 건수 반환
         } catch (JsonProcessingException e) {
             // JSON 파싱 관련 예외 처리


### PR DESCRIPTION
## 📌 작업 내용 (필수)
- 원본 데이터에 도로명 주소와 위도, 경도가 없으며, 지번 주소로도 조회되지 않는 경우, 해당 데이터를 가공 DB에 저장하지 않도록 수정했습니다.

<br/>

## 🌱 반영 브랜치
- refactor/#TT-67-spring-batch
- close #84 

<br/>

## 🔥 트러블 슈팅 (선택)
### ⚠️ 원본 맛집 데이터를 가공 맛집에 저장하는 과정에서 발생한 **6가지 주소 관련 문제**
#### 1. 문제 : 원본 데이터에 위도, 경도가 없어 가공 데이터가 저장되지 않음
  - **해결** : 원본 데이터의 지번 주소를 사용해 위도, 경도를 조회한 후, 이를 가공 데이터에 저장하도록 수정했습니다.
#### 2. 문제 : 지번 주소의 형식 오류로 인해 위도, 경도 조회 불가
  - **해결** : 지번 주소에 정제되지 않은 데이터가 많아 도로명 주소로 위도와 경도를 조회해 가공 데이터에 저장하도록 수정했습니다.
#### 3. 문제 : 지역 CSV 파일과 공공데이터 API의 좌표계 타입이 달라 지역 데이터와 원본 맛집 데이터의 위도, 경도 값에 충돌 발생
  - **상황** :
    - 지역 csv의 **WGS84 좌표계** 형식) lon : 128.8784972 / lat : 37.74913611
    - 공공데이터 API의 **중부원점TM 좌표계** 형식) lon : 451667.793301393 / lat : 200614.497822789
  - **해결** : 공공데이터 API의 응답 데이터를 원본 데이터에 저장하는 과정에서 주소 검색 openAPI를 활용해 WGS84 좌표계의 위도, 경도 데이터를 저장하도록 수정했습니다.
#### 4. 문제 : 원본 데이터에 도로명 주소가 없는 경우
  - **해결** : 지번주소를 이용해 위도, 경도를 조회한 후, 이를 저장하도록 수정했습니다.
#### 5. 문제 : 도로명 주소 형식 오류로 인해 가공 데이터가 저장되지 않음
  - **해결** : 지번주소를 이용해 위도, 경도를 조회한 후, 이를 저장하도록 수정했습니다.
![0904_1_119번째 타키](https://github.com/user-attachments/assets/a920f4d5-e606-4c00-b228-66c013cfa1f9)
#### 6. 문제 : 원본 데이터에 도로명 주소와 위도, 경도가 없으며, 지번 주소로도 조회되지 않는 경우
  - **해결** : 해당 데이터를 가공 DB에 저장하지 않도록 수정했습니다.
![0904_2_432번째 품청국장](https://github.com/user-attachments/assets/39508d1e-a6a6-425e-95e4-60168a420a0f)